### PR TITLE
Fix tooltip position based on the odd-even alternation of handles.

### DIFF
--- a/src/nouislider.tooltips.css
+++ b/src/nouislider.tooltips.css
@@ -8,15 +8,15 @@
 	text-align: center;
 }
 
-.noUi-horizontal .noUi-handle-lower .noUi-tooltip {
+.noUi-horizontal .noUi-origin:nth-child(odd) .noUi-tooltip {
 	top: -32px;
 }
-.noUi-horizontal .noUi-handle-upper .noUi-tooltip {
+.noUi-horizontal .noUi-origin:nth-child(even) .noUi-tooltip {
 	bottom: -32px;
 }
-.noUi-vertical .noUi-handle-lower .noUi-tooltip {
+.noUi-vertical .noUi-origin:nth-child(odd) .noUi-tooltip {
 	left: 120%;
 }
-.noUi-vertical .noUi-handle-upper .noUi-tooltip {
+.noUi-vertical .noUi-origin:nth-child(even) .noUi-tooltip {
 	right: 120%;
 }


### PR DESCRIPTION
This is based on the odd/even alternation of origins, to be precise. It keeps compatibility (it looks exactly the same for two handles) but it is not dependent on the lower/upper classes anymore, making it suitable for multiple handles.
